### PR TITLE
One change to solve a problem

### DIFF
--- a/src/googleIt.js
+++ b/src/googleIt.js
@@ -95,7 +95,7 @@ function getResults({ data, noDisplay, disableConsole, onlyUrls }) {
   });
 
   // result snippets
-  $('div.rc > div.s > span.st').map((index, elem) => {
+  $('div.rc > div.s > div > span.st').map((index, elem) => {
     if (index < results.length) {
       results[index] = Object.assign(results[index], {
         snippet: getSnippet(elem)


### PR DESCRIPTION
Maybe google changed the html format to show the results of the Google Search.

When you did a search with GoogleIt, it doesn't appears the snippet of the web results, the snippet text was moved into a new div element, only add the new div in the path and it's solved

![Screen Shot 2019-09-10 at 10 57 57 PM](https://user-images.githubusercontent.com/21228945/64667160-852df600-d41e-11e9-8ae6-3a7f78129d5a.png)

Compare it with the code, between <**div.s**> and <**span**>, there is a new blank <**div**>
There is my simple solution:

![Screen Shot 2019-09-10 at 11 01 48 PM](https://user-images.githubusercontent.com/21228945/64667315-07b6b580-d41f-11e9-91b5-de0ae8bf671a.png)

I hope to help you, and finally..
Google-It its a super nice tool, it's simple and powerful, It's what i was looking for, thanks :]
