### PR TITLE
add images folder to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ __tests__
 *.tgz
 .jest-cache
 .vscode
+images


### PR DESCRIPTION
Because majority of the package size comes from the images folder:
![image](https://user-images.githubusercontent.com/967811/71537255-5f523180-28e7-11ea-9f9e-f713283f20f1.png)

![image](https://user-images.githubusercontent.com/967811/71537256-637e4f00-28e7-11ea-9bb7-f9f2d2221502.png)
