### PR TITLE
set generated files in lib folder as main+bin entry points

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules/*.js
+lib/

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,0 +1,30 @@
+#! /usr/bin/env node
+
+/* eslint-disable no-console */
+"use strict";
+
+var ora = require('ora');
+
+var theSpinner = ora({
+  text: 'Loading results',
+  color: 'cyan'
+}).start();
+
+var parseCommandLineArgs = require('./parseCommandLineArgs');
+
+var validateCLIArguments = require('./validateCLIArguments');
+
+var googleIt = require('./main');
+
+var cliOptions = parseCommandLineArgs(process.argv);
+var validation = validateCLIArguments(cliOptions);
+
+if (!validation.valid) {
+  console.log("Invalid options. Error:  ".concat(validation.error));
+  theSpinner.clear();
+} else {
+  googleIt(cliOptions).then(function () {
+    theSpinner.stop();
+    theSpinner.clear();
+  }).catch(console.error);
+}

--- a/lib/googleIt.js
+++ b/lib/googleIt.js
@@ -1,0 +1,206 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.errorTryingToOpen = errorTryingToOpen;
+exports.openInBrowser = openInBrowser;
+exports.getSnippet = getSnippet;
+exports.display = display;
+exports.getResults = getResults;
+exports.getResponseBody = getResponseBody;
+exports.default = void 0;
+
+/* eslint-disable no-console */
+
+/* eslint-disable array-callback-return */
+var request = require('request');
+
+var fs = require('fs');
+
+var cheerio = require('cheerio');
+
+require('colors');
+
+var _require = require('child_process'),
+    exec = _require.exec;
+
+var _require2 = require('./utils'),
+    getDefaultRequestOptions = _require2.getDefaultRequestOptions,
+    getTitleSelector = _require2.getTitleSelector,
+    getLinkSelector = _require2.getLinkSelector,
+    getSnippetSelector = _require2.getSnippetSelector,
+    logIt = _require2.logIt,
+    saveToFile = _require2.saveToFile,
+    saveResponse = _require2.saveResponse;
+
+function errorTryingToOpen(error, stdout, stderr) {
+  if (error) {
+    console.log("Error trying to open link in browser: ".concat(error));
+    console.log("stdout: ".concat(stdout));
+    console.log("stderr: ".concat(stderr));
+  }
+}
+
+function openInBrowser(open, results) {
+  if (open !== undefined) {
+    // open is the first X number of links to open
+    results.slice(0, open).forEach(function (result) {
+      exec("open ".concat(result.link), errorTryingToOpen);
+    });
+  }
+}
+
+function getSnippet(elem) {
+  return elem.children.map(function (child) {
+    if (!child.data) {
+      return child.children.map(function (c) {
+        return c.data;
+      });
+    }
+
+    return child.data;
+  }).join('');
+}
+
+function display(results, disableConsole, onlyUrls) {
+  logIt('\n', disableConsole);
+  results.forEach(function (result) {
+    if (onlyUrls) {
+      logIt(result.link.green, disableConsole);
+    } else if (result.title) {
+      logIt(result.title.blue, disableConsole);
+      logIt(result.link.green, disableConsole);
+      logIt(result.snippet, disableConsole);
+      logIt('\n', disableConsole);
+    } else {
+      logIt('Result title is undefined.');
+    }
+  });
+}
+
+function getResults(_ref) {
+  var data = _ref.data,
+      noDisplay = _ref.noDisplay,
+      disableConsole = _ref.disableConsole,
+      onlyUrls = _ref.onlyUrls,
+      titleSelector = _ref.titleSelector,
+      linkSelector = _ref.linkSelector,
+      snippetSelector = _ref.snippetSelector;
+  var $ = cheerio.load(data);
+  var results = [];
+  var titles = $(getTitleSelector(titleSelector)).contents();
+  titles.each(function (index, elem) {
+    if (elem.data) {
+      results.push({
+        title: elem.data
+      });
+    } else {
+      results.push({
+        title: elem.children[0].data
+      });
+    }
+  });
+  $(getLinkSelector(linkSelector)).map(function (index, elem) {
+    if (index < results.length) {
+      results[index] = Object.assign(results[index], {
+        link: elem.attribs.href
+      });
+    }
+  });
+  $(getSnippetSelector(snippetSelector)).map(function (index, elem) {
+    if (index < results.length) {
+      results[index] = Object.assign(results[index], {
+        snippet: getSnippet(elem)
+      });
+    }
+  });
+
+  if (onlyUrls) {
+    results = results.map(function (r) {
+      return {
+        link: r.link
+      };
+    });
+  }
+
+  if (!noDisplay) {
+    display(results, disableConsole, onlyUrls);
+  }
+
+  return results;
+}
+
+function getResponseBody(_ref2) {
+  var filePath = _ref2.fromFile,
+      options = _ref2.options,
+      htmlFileOutputPath = _ref2.htmlFileOutputPath,
+      query = _ref2.query,
+      limit = _ref2.limit,
+      userAgent = _ref2.userAgent,
+      start = _ref2.start;
+  return new Promise(function (resolve, reject) {
+    if (filePath) {
+      fs.readFile(filePath, function (err, data) {
+        if (err) {
+          return reject(new Error("Erorr accessing file at ".concat(filePath, ": ").concat(err)));
+        }
+
+        return resolve(data);
+      });
+    } else {
+      var defaultOptions = getDefaultRequestOptions({
+        limit: limit,
+        query: query,
+        userAgent: userAgent,
+        start: start
+      });
+      request(Object.assign({}, defaultOptions, options), function (error, response, body) {
+        if (error) {
+          reject(new Error("Error making web request: ".concat(error)));
+        }
+
+        saveResponse(response, htmlFileOutputPath);
+        resolve(body);
+      });
+    }
+  });
+}
+
+function googleIt(config) {
+  var output = config.output,
+      open = config.open,
+      returnHtmlBody = config.returnHtmlBody,
+      titleSelector = config.titleSelector,
+      linkSelector = config.linkSelector,
+      snippetSelector = config.snippetSelector,
+      start = config.start;
+  return new Promise(function (resolve, reject) {
+    getResponseBody(config).then(function (body) {
+      var results = getResults({
+        data: body,
+        noDisplay: config['no-display'],
+        disableConsole: config.disableConsole,
+        onlyUrls: config['only-urls'],
+        titleSelector: titleSelector,
+        linkSelector: linkSelector,
+        snippetSelector: snippetSelector,
+        start: start
+      });
+      saveToFile(output, results);
+      openInBrowser(open, results);
+
+      if (returnHtmlBody) {
+        return resolve({
+          results: results,
+          body: body
+        });
+      }
+
+      return resolve(results);
+    }).catch(reject);
+  });
+}
+
+var _default = googleIt;
+exports.default = _default;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var _googleIt = _interopRequireDefault(require("./googleIt"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+module.exports = _googleIt.default;

--- a/lib/optionDefinitions.js
+++ b/lib/optionDefinitions.js
@@ -1,0 +1,89 @@
+"use strict";
+
+var optionDefinitions = [// the query that should be sent to the Google search
+{
+  name: 'query',
+  alias: 'q',
+  type: String
+}, // name of the JSON file to save results to
+{
+  name: 'output',
+  alias: 'o',
+  type: String
+}, // prevent results from appearing in the terminal output. Should only be used
+// with --output (-o) command when saving results to a file
+{
+  name: 'no-display',
+  alias: 'n',
+  type: Boolean
+}, // name of the html file if you want to save the actual response from the
+// html request
+{
+  name: 'save',
+  alias: 's',
+  type: String
+}, // number of search results to be returned
+{
+  name: 'limit',
+  alias: 'l',
+  type: Number
+}, // enable pagination by choosing which result to start at
+{
+  name: 'start',
+  type: Number
+}, // console.log useful statements to show what's currently taking place
+{
+  name: 'verbose',
+  alias: 'v',
+  type: Boolean
+}, // once results are returned, show them in an interactive prompt where user
+// can scroll through them
+{
+  name: 'interactive',
+  alias: 'i',
+  type: Boolean
+}, // only display the URLs, instead of the titles and snippets
+{
+  name: 'only-urls',
+  alias: 'u',
+  type: Boolean
+}, // only takes effect when interactive (-i) flag is set as well, will bold
+// test in results that matched the query
+{
+  name: 'bold-matching-text',
+  alias: 'b',
+  type: Boolean
+}, // option to limit results to only these two sites
+{
+  name: 'stackoverflow-github-only',
+  alias: 'X',
+  type: Boolean
+}, // option to open the first X number of results directly in browser
+// (only tested on Mac!).
+{
+  name: 'open',
+  alias: 'O',
+  type: Number
+}, // option to save the html file of the Google search result page
+{
+  name: 'htmlFileOutputPath',
+  alias: 'h',
+  type: String
+}, // option to use specific HTML file to parse, one that might exist locally
+// for example, main for debugging purposes
+{
+  name: 'fromFile',
+  alias: 'f',
+  type: String
+}, // override the hard-coded selectors defined inside /src/utils.js
+{
+  name: 'titleSelector',
+  type: String
+}, {
+  name: 'linkSelector',
+  type: String
+}, {
+  name: 'snippetSelector',
+  type: String
+}];
+module.exports = optionDefinitions;

--- a/lib/parseCommandLineArgs.js
+++ b/lib/parseCommandLineArgs.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var commandLineArgs = require('command-line-args');
+
+var optionDefinitions = require('./optionDefinitions');
+
+var parseCommandLineArgs = function parseCommandLineArgs(argv) {
+  var cliOptions = argv.length === 3 ? {
+    query: argv[2]
+  } : commandLineArgs(optionDefinitions); // first arg is 'node', second is /path/to/file/app.js, third is whatever follows afterward
+
+  if (argv.length > 2) {
+    // eslint-disable-next-line prefer-destructuring
+    cliOptions.query = argv[2].replace('--query=', '');
+  }
+
+  return cliOptions;
+};
+
+module.exports = parseCommandLineArgs;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,89 @@
+"use strict";
+
+/* eslint-disable no-console */
+var fs = require('fs');
+
+var _process$env = process.env,
+    GOOGLE_IT_TITLE_SELECTOR = _process$env.GOOGLE_IT_TITLE_SELECTOR,
+    GOOGLE_IT_LINK_SELECTOR = _process$env.GOOGLE_IT_LINK_SELECTOR,
+    GOOGLE_IT_SNIPPET_SELECTOR = _process$env.GOOGLE_IT_SNIPPET_SELECTOR; // NOTE:
+// I chose the User-Agent value from http://www.browser-info.net/useragents
+// Not setting one causes Google search to not display results
+
+var defaultUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:34.0) Gecko/20100101 Firefox/34.0';
+var defaultLimit = 10;
+var defaultStart = 0;
+
+var getDefaultRequestOptions = function getDefaultRequestOptions(_ref) {
+  var limit = _ref.limit,
+      query = _ref.query,
+      userAgent = _ref.userAgent,
+      start = _ref.start;
+  return {
+    url: 'https://www.google.com/search',
+    qs: {
+      q: query,
+      num: limit || defaultLimit,
+      start: start || defaultStart
+    },
+    headers: {
+      'User-Agent': userAgent || defaultUserAgent
+    }
+  };
+};
+
+var titleSelector = '#rso > div > div > div > div > div > div.r > a > h3';
+var linkSelector = 'div.rc > div.r > a';
+var snippetSelector = '#rso > div > div > div > div > div > div.s > div > span';
+
+var getTitleSelector = function getTitleSelector(passedValue) {
+  return passedValue || GOOGLE_IT_TITLE_SELECTOR || titleSelector;
+};
+
+var getLinkSelector = function getLinkSelector(passedValue) {
+  return passedValue || GOOGLE_IT_LINK_SELECTOR || linkSelector;
+};
+
+var getSnippetSelector = function getSnippetSelector(passedValue) {
+  return passedValue || GOOGLE_IT_SNIPPET_SELECTOR || snippetSelector;
+};
+
+var logIt = function logIt(message, disableConsole) {
+  if (!disableConsole) {
+    console.log(message);
+  }
+};
+
+var saveToFile = function saveToFile(output, results) {
+  if (output !== undefined) {
+    fs.writeFile(output, JSON.stringify(results, null, 2), 'utf8', function (err) {
+      if (err) {
+        console.error("Error writing to file ".concat(output, ": ").concat(err));
+      }
+    });
+  }
+};
+
+var saveResponse = function saveResponse(response, htmlFileOutputPath) {
+  if (htmlFileOutputPath) {
+    fs.writeFile(htmlFileOutputPath, response.body, function () {
+      console.log("Html file saved to ".concat(htmlFileOutputPath));
+    });
+  }
+};
+
+module.exports = {
+  defaultUserAgent: defaultUserAgent,
+  defaultLimit: defaultLimit,
+  defaultStart: defaultStart,
+  getDefaultRequestOptions: getDefaultRequestOptions,
+  getTitleSelector: getTitleSelector,
+  getLinkSelector: getLinkSelector,
+  titleSelector: titleSelector,
+  linkSelector: linkSelector,
+  snippetSelector: snippetSelector,
+  getSnippetSelector: getSnippetSelector,
+  logIt: logIt,
+  saveToFile: saveToFile,
+  saveResponse: saveResponse
+};

--- a/lib/validateCLIArguments.js
+++ b/lib/validateCLIArguments.js
@@ -1,0 +1,45 @@
+"use strict";
+
+var _validationMap;
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var MISSING_QUERY = 'missing_query';
+var OUTPUT_ARG_MUST_BE_STRING = 'output_arg_must_be_string';
+var MUST_END_IN_JSON = 'must_end_in_json';
+var ONLY_ONE_NOT_BOTH = 'only_one_not_both';
+
+function getError(reason) {
+  return {
+    valid: false,
+    Error: reason
+  };
+}
+
+var validationMap = (_validationMap = {}, _defineProperty(_validationMap, MISSING_QUERY, getError('Missing query')), _defineProperty(_validationMap, OUTPUT_ARG_MUST_BE_STRING, getError('Output argument must be string')), _defineProperty(_validationMap, MUST_END_IN_JSON, getError('Output argument must end in .json')), _defineProperty(_validationMap, ONLY_ONE_NOT_BOTH, getError('Can only use --no-display when --output is used as well')), _validationMap);
+
+function getPotentialError(args) {
+  var error = null;
+
+  if (!args.query) {
+    error = MISSING_QUERY;
+  } else if (args.output && typeof args.output !== 'string') {
+    error = OUTPUT_ARG_MUST_BE_STRING;
+  } else if (args.output && !args.output.endsWith('.json')) {
+    error = MUST_END_IN_JSON;
+  } else if (args['no-display'] && !args.output) {
+    error = ONLY_ONE_NOT_BOTH;
+  }
+
+  return validationMap[error];
+}
+
+function validateCLIArguments(args) {
+  var result = {
+    valid: true
+  };
+  var error = getPotentialError(args);
+  return error || result;
+}
+
+module.exports = validateCLIArguments;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,37 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/cli": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.7.7.tgz",
+      "integrity": "sha512-XQw5KyCZyu/M8/0rYiZyuwbgIQNzOrJzs9dDLX+MieSgBwTLvTj4QVbLmxJACAIvQIDT7PtyHN2sC48EOWTgaA==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.1.8",
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "lodash": "^4.17.13",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
+          "integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -1592,6 +1623,13 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true,
+      "optional": true
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -1965,6 +2003,13 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true,
+      "optional": true
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -2189,6 +2234,59 @@
         "htmlparser2": "^3.9.1",
         "lodash": "^4.15.0",
         "parse5": "^3.0.1"
+      }
+    },
+    "chokidar": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "ci-info": {
@@ -3560,6 +3658,12 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4728,6 +4832,16 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -6696,6 +6810,13 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true,
+      "optional": true
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -6903,6 +7024,18 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
+      }
+    },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
       }
     },
     "realpath-native": {
@@ -8184,6 +8317,13 @@
           "dev": true
         }
       }
+    },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true,
+      "optional": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -2,15 +2,17 @@
   "name": "google-it",
   "version": "1.4.0",
   "description": "A CLI and Node.js library to help retrieve, display, and store Google search results",
-  "main": "./src/googleIt.js",
-  "bin": "./src/app.js",
+  "main": "./lib/main.js",
+  "bin": "./lib/app.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/PatNeedham/google-it.git"
   },
   "scripts": {
+    "build": "babel src -d lib",
     "lint": "./node_modules/.bin/eslint --ext .js --ignore-path .eslintignore '*.js'",
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "npm run build"
   },
   "keywords": [
     "google-search",
@@ -38,6 +40,8 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.7.7",
+    "@babel/core": "^7.7.7",
     "amex-jest-preset": "^5.0.0",
     "babel-preset-amex": "^3.3.0",
     "codecov": "^3.6.1",

--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,7 @@ const ora = require('ora');
 const theSpinner = ora({ text: 'Loading results', color: 'cyan' }).start();
 const parseCommandLineArgs = require('./parseCommandLineArgs');
 const validateCLIArguments = require('./validateCLIArguments');
-const googleIt = require('./googleIt');
+const googleIt = require('./main');
 
 const cliOptions = parseCommandLineArgs(process.argv);
 const validation = validateCLIArguments(cliOptions);

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,3 @@
+import googleIt from './googleIt';
+
+module.exports = googleIt;


### PR DESCRIPTION
Adding a `src/lib/main.js` became necessary due to `node` no longer picking up function within `src/googleIt.js` via the `export default googleIt` statement:

![image](https://user-images.githubusercontent.com/967811/71537836-c542b700-28ef-11ea-990f-7160c90207fb.png)

The way around this would be to make consumers change their imports to:
```
const googleIt = require('google-it').default;
```
Which would be a breaking change and undesirable for now. (more changes need to be made before `google-it` v2 is ready!).

Also worth pointing out, the `lib` folder is not added to .gitignore yet. That will happen once the release process becomes formalized. At that point, I should be able to that after utilizing a dev dependency such as [standard-version](https://www.npmjs.com/package/standard-version)