### PR TITLE
Fix selectors

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,9 +32,9 @@ var getDefaultRequestOptions = function getDefaultRequestOptions(_ref) {
   };
 };
 
-var titleSelector = '#rso > div > div > div > div > div > div.r > a > h3';
+var titleSelector = 'div.rc > div.r > a > h3';
 var linkSelector = 'div.rc > div.r > a';
-var snippetSelector = '#rso > div > div > div > div > div > div.s > div > span';
+var snippetSelector = 'div.rc > div.s > div > span';
 
 var getTitleSelector = function getTitleSelector(passedValue) {
   return passedValue || GOOGLE_IT_TITLE_SELECTOR || titleSelector;

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,9 +30,9 @@ const getDefaultRequestOptions = ({
   },
 });
 
-const titleSelector = '#rso > div > div > div > div > div > div.r > a > h3';
+const titleSelector = 'div.rc > div.r > a > h3';
 const linkSelector = 'div.rc > div.r > a';
-const snippetSelector = '#rso > div > div > div > div > div > div.s > div > span';
+const snippetSelector = 'div.rc > div.s > div > span';
 
 const getTitleSelector = passedValue => (
   passedValue || GOOGLE_IT_TITLE_SELECTOR || titleSelector


### PR DESCRIPTION
The current selectors do capture results if there is only 1 result in the Google search. This is because Google will use a container div for 2 or more results, but no container if there is only 1 result. Current selectors expect the container div. This fixes that.