### PR TITLE
make html test data not detectable to linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+__tests__/data/* -linguist-detectable
+*.html linguist-detectable=false
+__tests__/data/*.html -linguist-detectable
+__tests__/data/*.html linguist-detectable=false
+__tests__/data/* linguist-vendored
+__tests__/data/* linguist-generated
+__tests__/data/*.html linguist-generated
+__tests__/data/speed-of-light-divided-by-2.html linguist-generated
+
+__tests__/data/speed-of-light-divided-by-2.html -linguist-detectable
+__tests__/data/speed-of-light-divided-by-2.html linguist-detectable=false
+
+coverage/* -linguist-detectable
+coverage/* linguist-detectable=false


### PR DESCRIPTION
This is to get rid of the hideous red HTML that's being counted towards the language statistics:

![image](https://user-images.githubusercontent.com/967811/73224595-fead5300-4137-11ea-8107-e17904247e8c.png)


Apparently Github doesn't do the breakdown on a branch by branch basis because when I switch to other, much older branches before I added the one HTML test file, HTML has the same majority proportion as when viewing it on master, or on this branch,