### PR TITLE
Fix document selectors to get title/snippet correctly

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,9 +34,9 @@ var getDefaultRequestOptions = function getDefaultRequestOptions(_ref) {
   };
 };
 
-var titleSelector = 'div.rc > div.r > a > h3';
-var linkSelector = 'div.rc > div.r > a';
-var snippetSelector = 'div.rc > div.s > div > span';
+var titleSelector = 'div.rc > div:nth-child(1) > a > h3';
+var linkSelector = 'div.rc > div:nth-child(1) > a';
+var snippetSelector = 'div.rc > div:nth-child(2) > div > span';
 var resultStatsSelector = '#resultStats';
 var cursorSelector = '#nav > tbody > tr > td.cur';
 


### PR DESCRIPTION
Seems like google search's document structure has slightly changed, with the classes `r` and `s` removed, which broke this module. 

I've replaced the selectors with more basic ones, which select the 1st and 2nd child respectively, instead of selecting by class.

Fixes #54.