### PR TITLE
feat(include/exclude): add new CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Prevent display in the terminal, and save results to a JSON file:
 - [ ] *verbose* - console.log useful statements to show what's currently taking place
 - [ ] *interactive* - once results are returned, show them in an interactive prompt where user can scroll through them
 - [ ] *bold-matching-text* - only takes effect when interactive (-i) flag is set as well, will bold test in results that matched the query
-- [ ] *stackoverflow-github-only* - option to limit results to only these two sites
+- [x] *includeSites* - option to limit results to comma-separated list of sites
+- [x] *excludeSites* - option to exclude results that appear in comma-separated list of sites
 - [x] *open* - opens the first X number of results in the browser after finishing query
 - [x] *disableConsole* - intended to be used with programmatic use, so that the color-coded search results are not displayed in the terminal (via console.log) when not wanted.
 

--- a/__tests__/utils.spec.js
+++ b/__tests__/utils.spec.js
@@ -16,6 +16,7 @@ import {
   logIt,
   saveToFile,
   saveResponse,
+  getFullQuery,
 } from '../src/utils';
 
 global.console = {
@@ -113,5 +114,16 @@ describe('saveResponse', () => {
     });
     saveResponse('foo', '/path/to/my/meaningless/response.xml');
     expect(fs.writeFile).toHaveBeenCalled();
+  });
+});
+
+describe('getFullQuery', () => {
+  it('adds "site:a.com OR site:b.com" when includeSites arg is "a.com,b.com"', () => {
+    const result = getFullQuery('something', 'a.com,b.com', '');
+    expect(result.includes('site:a.com OR site:b.com')).toBe(true);
+  });
+  it('adds "-site:a.com AND -site:b.com" when excludeSites arg is "a.com,b.com"', () => {
+    const result = getFullQuery('something', '', 'a.com,b.com');
+    expect(result.includes('-site:a.com AND -site:b.com')).toBe(true);
   });
 });

--- a/lib/googleIt.js
+++ b/lib/googleIt.js
@@ -170,7 +170,9 @@ function getResponse(_ref2) {
       query = _ref2.query,
       limit = _ref2.limit,
       userAgent = _ref2.userAgent,
-      start = _ref2.start;
+      start = _ref2.start,
+      includeSites = _ref2.includeSites,
+      excludeSites = _ref2.excludeSites;
   // eslint-disable-next-line consistent-return
   return new Promise(function (resolve, reject) {
     if (filePath) {
@@ -193,7 +195,9 @@ function getResponse(_ref2) {
       limit: limit,
       query: query,
       userAgent: userAgent,
-      start: start
+      start: start,
+      includeSites: includeSites,
+      excludeSites: excludeSites
     });
     request(_objectSpread(_objectSpread({}, defaultOptions), options), function (error, response, body) {
       if (error) {

--- a/lib/optionDefinitions.js
+++ b/lib/optionDefinitions.js
@@ -53,11 +53,6 @@ var optionDefinitions = [// the query that should be sent to the Google search
   name: 'bold-matching-text',
   alias: 'b',
   type: Boolean
-}, // option to limit results to only these two sites
-{
-  name: 'stackoverflow-github-only',
-  alias: 'X',
-  type: Boolean
 }, // option to open the first X number of results directly in browser
 // (only tested on Mac!).
 {
@@ -90,5 +85,15 @@ var optionDefinitions = [// the query that should be sent to the Google search
   name: 'diagnostics',
   alias: 'd',
   type: Boolean
+}, // modifies the search query by adding "site:" operator for each comma-separated value,
+// combined with OR operator when there are multiple values
+{
+  name: 'includeSites',
+  type: String
+}, // modifies the search query by adding "-site:" operator for each comma-separated value,
+// combined with AND operator when there are multiple values
+{
+  name: 'excludeSites',
+  type: String
 }];
 module.exports = optionDefinitions;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,11 @@ var _process$env = process.env,
     GOOGLE_IT_LINK_SELECTOR = _process$env.GOOGLE_IT_LINK_SELECTOR,
     GOOGLE_IT_SNIPPET_SELECTOR = _process$env.GOOGLE_IT_SNIPPET_SELECTOR,
     GOOGLE_IT_RESULT_STATS_SELECTOR = _process$env.GOOGLE_IT_RESULT_STATS_SELECTOR,
-    GOOGLE_IT_CURSOR_SELECTOR = _process$env.GOOGLE_IT_CURSOR_SELECTOR; // NOTE:
+    GOOGLE_IT_CURSOR_SELECTOR = _process$env.GOOGLE_IT_CURSOR_SELECTOR,
+    _process$env$GOOGLE_I = _process$env.GOOGLE_IT_INCLUDE_SITES,
+    GOOGLE_IT_INCLUDE_SITES = _process$env$GOOGLE_I === void 0 ? '' : _process$env$GOOGLE_I,
+    _process$env$GOOGLE_I2 = _process$env.GOOGLE_IT_EXCLUDE_SITES,
+    GOOGLE_IT_EXCLUDE_SITES = _process$env$GOOGLE_I2 === void 0 ? '' : _process$env$GOOGLE_I2; // NOTE:
 // I chose the User-Agent value from http://www.browser-info.net/useragents
 // Not setting one causes Google search to not display results
 
@@ -18,15 +22,39 @@ var defaultUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:34.0) G
 var defaultLimit = 10;
 var defaultStart = 0;
 
+var getFullQuery = function getFullQuery(query) {
+  var includeSites = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : GOOGLE_IT_INCLUDE_SITES;
+  var excludeSites = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : GOOGLE_IT_EXCLUDE_SITES;
+
+  if (includeSites === '' && excludeSites === '') {
+    return query;
+  }
+
+  if (includeSites !== '') {
+    var _addition = includeSites.split(',').map(function (site) {
+      return " site:".concat(site);
+    }).join(' OR');
+
+    return query + _addition;
+  }
+
+  var addition = excludeSites.split(',').map(function (site) {
+    return " -site:".concat(site);
+  }).join(' AND');
+  return query + addition;
+};
+
 var getDefaultRequestOptions = function getDefaultRequestOptions(_ref) {
   var limit = _ref.limit,
       query = _ref.query,
       userAgent = _ref.userAgent,
-      start = _ref.start;
+      start = _ref.start,
+      includeSites = _ref.includeSites,
+      excludeSites = _ref.excludeSites;
   return {
     url: 'https://www.google.com/search',
     qs: {
-      q: query,
+      q: getFullQuery(query, includeSites, excludeSites),
       num: limit || defaultLimit,
       start: start || defaultStart
     },
@@ -102,5 +130,6 @@ module.exports = {
   getResultCursorSelector: getResultCursorSelector,
   logIt: logIt,
   saveToFile: saveToFile,
-  saveResponse: saveResponse
+  saveResponse: saveResponse,
+  getFullQuery: getFullQuery
 };

--- a/src/googleIt.js
+++ b/src/googleIt.js
@@ -134,6 +134,8 @@ export function getResponse({
   limit,
   userAgent,
   start,
+  includeSites,
+  excludeSites,
 }) {
   // eslint-disable-next-line consistent-return
   return new Promise((resolve, reject) => {
@@ -148,7 +150,7 @@ export function getResponse({
       return resolve({ body: fromString });
     }
     const defaultOptions = getDefaultRequestOptions({
-      limit, query, userAgent, start,
+      limit, query, userAgent, start, includeSites, excludeSites,
     });
     request({ ...defaultOptions, ...options }, (error, response, body) => {
       if (error) {

--- a/src/optionDefinitions.js
+++ b/src/optionDefinitions.js
@@ -33,9 +33,6 @@ const optionDefinitions = [
   // test in results that matched the query
   { name: 'bold-matching-text', alias: 'b', type: Boolean },
 
-  // option to limit results to only these two sites
-  { name: 'stackoverflow-github-only', alias: 'X', type: Boolean },
-
   // option to open the first X number of results directly in browser
   // (only tested on Mac!).
   { name: 'open', alias: 'O', type: Number },
@@ -54,6 +51,14 @@ const optionDefinitions = [
 
   // allows for googleIt result object to include raw network request's response
   { name: 'diagnostics', alias: 'd', type: Boolean },
+
+  // modifies the search query by adding "site:" operator for each comma-separated value,
+  // combined with OR operator when there are multiple values
+  { name: 'includeSites', type: String },
+
+  // modifies the search query by adding "-site:" operator for each comma-separated value,
+  // combined with AND operator when there are multiple values
+  { name: 'excludeSites', type: String },
 ];
 
 module.exports = optionDefinitions;

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,8 @@ const {
   GOOGLE_IT_SNIPPET_SELECTOR,
   GOOGLE_IT_RESULT_STATS_SELECTOR,
   GOOGLE_IT_CURSOR_SELECTOR,
+  GOOGLE_IT_INCLUDE_SITES = '',
+  GOOGLE_IT_EXCLUDE_SITES = '',
 } = process.env;
 
 // NOTE:
@@ -19,12 +21,28 @@ const defaultUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:34.0)
 const defaultLimit = 10;
 const defaultStart = 0;
 
+const getFullQuery = (
+  query,
+  includeSites = GOOGLE_IT_INCLUDE_SITES,
+  excludeSites = GOOGLE_IT_EXCLUDE_SITES
+) => {
+  if (includeSites === '' && excludeSites === '') {
+    return query;
+  }
+  if (includeSites !== '') {
+    const addition = includeSites.split(',').map((site) => ` site:${site}`).join(' OR');
+    return query + addition;
+  }
+  const addition = excludeSites.split(',').map((site) => ` -site:${site}`).join(' AND');
+  return query + addition;
+};
+
 const getDefaultRequestOptions = ({
-  limit, query, userAgent, start,
+  limit, query, userAgent, start, includeSites, excludeSites,
 }) => ({
   url: 'https://www.google.com/search',
   qs: {
-    q: query,
+    q: getFullQuery(query, includeSites, excludeSites),
     num: limit || defaultLimit,
     start: start || defaultStart,
   },
@@ -100,4 +118,5 @@ module.exports = {
   logIt,
   saveToFile,
   saveResponse,
+  getFullQuery,
 };


### PR DESCRIPTION
Adds the `includeSites` and `excludeSites` CLI options, as well as `GOOGLE_IT_INCLUDE_SITES` and `GOOGLE_IT_EXCLUDE_SITES` environment variables.

![image](https://user-images.githubusercontent.com/967811/101308385-b959b780-3817-11eb-9828-8f52ee9fdd74.png)
