### PR TITLE
fix title & link selectors

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -51,8 +51,8 @@ const getDefaultRequestOptions = ({
   },
 });
 
-const titleSelector = 'div.ZINbbc > div:nth-child(1) > a > h3';
-const linkSelector = 'div.ZINbbc > div:nth-child(1) > a';
+var titleSelector = 'div.fP1Qef > div:nth-child(1) > a > h3';
+var linkSelector = 'div.fP1Qef > div:nth-child(1) > a';
 const snippetSelector = '#main > div > div > div > div:not(.v9i61e) > div.AP7Wnd';
 const resultStatsSelector = '#resultStats';
 const cursorSelector = '#nav > tbody > tr > td.cur';


### PR DESCRIPTION
Google changed their selectors yet again, so this update fixes the package to make it work with the new selectors.

Fixes #86 