### PR TITLE
Expose titleFinder to allow providing your own

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -3,27 +3,21 @@
 /* eslint-disable no-console */
 "use strict";
 
-var ora = require('ora');
-
-var theSpinner = ora({
+const ora = require('ora');
+const theSpinner = ora({
   text: 'Loading results',
   color: 'cyan'
 }).start();
-
-var parseCommandLineArgs = require('./parseCommandLineArgs');
-
-var validateCLIArguments = require('./validateCLIArguments');
-
-var googleIt = require('./main');
-
-var cliOptions = parseCommandLineArgs(process.argv);
-var validation = validateCLIArguments(cliOptions);
-
+const parseCommandLineArgs = require('./parseCommandLineArgs');
+const validateCLIArguments = require('./validateCLIArguments');
+const googleIt = require('./main');
+const cliOptions = parseCommandLineArgs(process.argv);
+const validation = validateCLIArguments(cliOptions);
 if (!validation.valid) {
-  console.log("Invalid options. Error:  ".concat(validation.error));
+  console.log(`Invalid options. Error:  ${validation.error}`);
   theSpinner.clear();
 } else {
-  googleIt(cliOptions).then(function () {
+  googleIt(cliOptions).then(() => {
     theSpinner.stop();
     theSpinner.clear();
   }).catch(console.error);

--- a/lib/googleIt.js
+++ b/lib/googleIt.js
@@ -3,88 +3,68 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.errorTryingToOpen = errorTryingToOpen;
-exports.openInBrowser = openInBrowser;
-exports.getSnippet = getSnippet;
+exports.default = void 0;
 exports.display = display;
-exports.getResults = getResults;
+exports.errorTryingToOpen = errorTryingToOpen;
 exports.getResponse = getResponse;
-exports.default = exports.parseGoogleSearchResultUrl = void 0;
-
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
+exports.getResults = getResults;
+exports.getSnippet = getSnippet;
+exports.openInBrowser = openInBrowser;
+exports.parseGoogleSearchResultUrl = void 0;
 /* eslint-disable no-console */
-
 /* eslint-disable array-callback-return */
-var request = require('request');
-
-var fs = require('fs');
-
-var querystring = require('querystring');
-
-var cheerio = require('cheerio');
-
+const request = require('request');
+const fs = require('fs');
+const querystring = require('querystring');
+const cheerio = require('cheerio');
 require('colors');
-
-var _require = require('child_process'),
-    exec = _require.exec;
-
-var _require2 = require('./utils'),
-    getDefaultRequestOptions = _require2.getDefaultRequestOptions,
-    getTitleSelector = _require2.getTitleSelector,
-    getLinkSelector = _require2.getLinkSelector,
-    getSnippetSelector = _require2.getSnippetSelector,
-    getResultStatsSelector = _require2.getResultStatsSelector,
-    getResultCursorSelector = _require2.getResultCursorSelector,
-    logIt = _require2.logIt,
-    saveToFile = _require2.saveToFile,
-    saveResponse = _require2.saveResponse,
-    titlefinder = _require2.titlefinder;
-
+const {
+  exec
+} = require('child_process');
+const {
+  getDefaultRequestOptions,
+  getTitleSelector,
+  getTitleFinder,
+  getLinkSelector,
+  getSnippetSelector,
+  getResultStatsSelector,
+  getResultCursorSelector,
+  logIt,
+  saveToFile,
+  saveResponse
+} = require('./utils');
 function errorTryingToOpen(error, stdout, stderr) {
   if (error) {
-    console.log("Error trying to open link in browser: ".concat(error));
-    console.log("stdout: ".concat(stdout));
-    console.log("stderr: ".concat(stderr));
+    console.log(`Error trying to open link in browser: ${error}`);
+    console.log(`stdout: ${stdout}`);
+    console.log(`stderr: ${stderr}`);
   }
 }
-
 function openInBrowser(open, results) {
   if (open !== undefined) {
     // open is the first X number of links to open
-    results.slice(0, open).forEach(function (result) {
-      exec("open ".concat(result.link), errorTryingToOpen);
+    results.slice(0, open).forEach(result => {
+      exec(`open ${result.link}`, errorTryingToOpen);
     });
   }
 }
-
 function getSnippet(elem) {
   // recursive function to get "all" the returned data from Google
   function findData(child) {
     if (!child.data) {
-      return child.children.map(function (c) {
-        return c.data || findData(c);
-      });
+      return child.children.map(c => c.data || findData(c));
     }
-
     return child.data;
-  } // Issue with linter wanting "new" before "Array"
+  }
+
+  // Issue with linter wanting "new" before "Array"
   // in this case, the casting is legit, we don't want a new array
   // eslint-disable-next-line unicorn/new-for-builtins
-
-
-  return elem.children && elem.children.length > 0 ? elem.children.map(function (child) {
-    return Array(findData(child)).join('');
-  }).join('') : '';
+  return elem.children && elem.children.length > 0 ? elem.children.map(child => Array(findData(child)).join('')).join('') : '';
 }
-
 function display(results, disableConsole, onlyUrls) {
   logIt('\n', disableConsole);
-  results.forEach(function (result) {
+  results.forEach(result => {
     if (onlyUrls) {
       logIt(result.link.green, disableConsole);
     } else if (result.title) {
@@ -97,35 +77,33 @@ function display(results, disableConsole, onlyUrls) {
     }
   });
 }
-
-var parseGoogleSearchResultUrl = function parseGoogleSearchResultUrl(url) {
+const parseGoogleSearchResultUrl = url => {
   if (!url) {
     return undefined;
   }
-
   if (url.charAt(0) === '/') {
     return querystring.parse(url).url;
   }
-
   return url;
 };
-
 exports.parseGoogleSearchResultUrl = parseGoogleSearchResultUrl;
-
 function getResults(_ref) {
-  var data = _ref.data,
-      noDisplay = _ref.noDisplay,
-      disableConsole = _ref.disableConsole,
-      onlyUrls = _ref.onlyUrls,
-      titleSelector = _ref.titleSelector,
-      linkSelector = _ref.linkSelector,
-      snippetSelector = _ref.snippetSelector,
-      resultStatsSelector = _ref.resultStatsSelector,
-      cursorSelector = _ref.cursorSelector;
-  var $ = cheerio.load(data);
-  var results = [];
-  var titles = $(getTitleSelector(titleSelector)).find(titlefinder);
-  titles.each(function (index, elem) {
+  let {
+    data,
+    noDisplay,
+    disableConsole,
+    onlyUrls,
+    titleSelector,
+    titleFinder,
+    linkSelector,
+    snippetSelector,
+    resultStatsSelector,
+    cursorSelector
+  } = _ref;
+  const $ = cheerio.load(data);
+  let results = [];
+  const titles = $(getTitleSelector(titleSelector)).find(getTitleFinder(titleFinder));
+  titles.each((index, elem) => {
     if (elem.children[0].data) {
       results.push({
         title: elem.children[0].data
@@ -136,68 +114,63 @@ function getResults(_ref) {
       });
     }
   });
-  $(getLinkSelector(linkSelector)).map(function (index, elem) {
+  $(getLinkSelector(linkSelector)).map((index, elem) => {
     if (index < results.length) {
       results[index] = Object.assign(results[index], {
         link: parseGoogleSearchResultUrl(elem.attribs.href)
       });
     }
   });
-  $(getSnippetSelector(snippetSelector)).map(function (index, elem) {
+  $(getSnippetSelector(snippetSelector)).map((index, elem) => {
     if (index < results.length) {
       results[index] = Object.assign(results[index], {
         snippet: getSnippet(elem)
       });
     }
   });
-
   if (onlyUrls) {
-    results = results.map(function (r) {
-      return {
-        link: r.link
-      };
-    });
+    results = results.map(r => ({
+      link: r.link
+    }));
   }
-
   if (!noDisplay) {
     display(results, disableConsole, onlyUrls);
   }
-
-  var resultStats = $(getResultStatsSelector(resultStatsSelector)).html() || '';
-  var approximateResults = ((resultStats.split(' results') || [''])[0].split('About ')[1] || '').replace(',', '');
-  var seconds = parseFloat((resultStats.split(' (')[1] || '').split(' seconds')[0]);
-  var cursor = $(getResultCursorSelector(cursorSelector)).html() || '';
-  var page = parseInt(cursor.split('</span>')[1], 10);
-  var stats = {
-    page: page,
-    approximateResults: approximateResults,
-    seconds: seconds
+  const resultStats = $(getResultStatsSelector(resultStatsSelector)).html() || '';
+  const approximateResults = ((resultStats.split(' results') || [''])[0].split('About ')[1] || '').replace(',', '');
+  const seconds = parseFloat((resultStats.split(' (')[1] || '').split(' seconds')[0]);
+  const cursor = $(getResultCursorSelector(cursorSelector)).html() || '';
+  const page = parseInt(cursor.split('</span>')[1], 10);
+  const stats = {
+    page,
+    approximateResults,
+    seconds
   };
   return {
-    results: results,
-    stats: stats
+    results,
+    stats
   };
 }
-
 function getResponse(_ref2) {
-  var filePath = _ref2.fromFile,
-      fromString = _ref2.fromString,
-      options = _ref2.options,
-      htmlFileOutputPath = _ref2.htmlFileOutputPath,
-      query = _ref2.query,
-      limit = _ref2.limit,
-      userAgent = _ref2.userAgent,
-      start = _ref2.start,
-      includeSites = _ref2.includeSites,
-      excludeSites = _ref2.excludeSites;
+  let {
+    fromFile: filePath,
+    fromString,
+    options,
+    htmlFileOutputPath,
+    query,
+    limit,
+    userAgent,
+    start,
+    includeSites,
+    excludeSites
+  } = _ref2;
   // eslint-disable-next-line consistent-return
-  return new Promise(function (resolve, reject) {
+  return new Promise((resolve, reject) => {
     if (filePath) {
-      fs.readFile(filePath, function (err, data) {
+      fs.readFile(filePath, (err, data) => {
         if (err) {
-          return reject(new Error("Erorr accessing file at ".concat(filePath, ": ").concat(err)));
+          return reject(new Error(`Erorr accessing file at ${filePath}: ${err}`));
         }
-
         return resolve({
           body: data
         });
@@ -207,82 +180,84 @@ function getResponse(_ref2) {
         body: fromString
       });
     }
-
-    var defaultOptions = getDefaultRequestOptions({
-      limit: limit,
-      query: query,
-      userAgent: userAgent,
-      start: start,
-      includeSites: includeSites,
-      excludeSites: excludeSites
+    const defaultOptions = getDefaultRequestOptions({
+      limit,
+      query,
+      userAgent,
+      start,
+      includeSites,
+      excludeSites
     });
-    request(_objectSpread(_objectSpread({}, defaultOptions), options), function (error, response, body) {
+    request({
+      ...defaultOptions,
+      ...options
+    }, (error, response, body) => {
       if (error) {
-        return reject(new Error("Error making web request: ".concat(error)));
+        return reject(new Error(`Error making web request: ${error}`));
       }
-
       saveResponse(response, htmlFileOutputPath);
       return resolve({
-        body: body,
-        response: response
+        body,
+        response
       });
     });
   });
 }
-
 function googleIt(config) {
-  var output = config.output,
-      open = config.open,
-      returnHtmlBody = config.returnHtmlBody,
-      titleSelector = config.titleSelector,
-      linkSelector = config.linkSelector,
-      snippetSelector = config.snippetSelector,
-      resultStatsSelector = config.resultStatsSelector,
-      cursorSelector = config.cursorSelector,
-      start = config.start,
-      diagnostics = config.diagnostics;
-  return new Promise(function (resolve, reject) {
-    getResponse(config).then(function (_ref3) {
-      var body = _ref3.body,
-          response = _ref3.response;
-
-      var _getResults = getResults({
+  const {
+    output,
+    open,
+    returnHtmlBody,
+    titleSelector,
+    titleFinder,
+    linkSelector,
+    snippetSelector,
+    resultStatsSelector,
+    cursorSelector,
+    start,
+    diagnostics
+  } = config;
+  return new Promise((resolve, reject) => {
+    getResponse(config).then(_ref3 => {
+      let {
+        body,
+        response
+      } = _ref3;
+      const {
+        results,
+        stats
+      } = getResults({
         data: body,
         noDisplay: config['no-display'],
         disableConsole: config.disableConsole,
         onlyUrls: config['only-urls'],
-        titleSelector: titleSelector,
-        linkSelector: linkSelector,
-        snippetSelector: snippetSelector,
-        resultStatsSelector: resultStatsSelector,
-        cursorSelector: cursorSelector,
-        start: start
-      }),
-          results = _getResults.results,
-          stats = _getResults.stats;
-
-      var statusCode = response.statusCode;
-
+        titleSelector,
+        titleFinder,
+        linkSelector,
+        snippetSelector,
+        resultStatsSelector,
+        cursorSelector,
+        start
+      });
+      const {
+        statusCode
+      } = response;
       if (results.length === 0 && statusCode !== 200 && !diagnostics) {
-        reject(new Error("Error in response: statusCode ".concat(statusCode, ". To see the raw response object, please include the 'diagnostics: true' as part of the options object (or -d if using command line)")));
+        reject(new Error(`Error in response: statusCode ${statusCode}. To see the raw response object, please include the 'diagnostics: true' as part of the options object (or -d if using command line)`));
       }
-
       saveToFile(output, results);
       openInBrowser(open, results);
-
       if (returnHtmlBody || diagnostics) {
         return resolve({
-          results: results,
-          body: body,
-          response: response,
-          stats: stats
+          results,
+          body,
+          response,
+          stats
         });
       }
-
       return resolve(results);
     }).catch(reject);
   });
 }
-
 var _default = googleIt;
 exports.default = _default;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,5 @@
 "use strict";
 
 var _googleIt = _interopRequireDefault(require("./googleIt"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 module.exports = _googleIt.default;

--- a/lib/optionDefinitions.js
+++ b/lib/optionDefinitions.js
@@ -1,76 +1,90 @@
 "use strict";
 
-var optionDefinitions = [// the query that should be sent to the Google search
+const optionDefinitions = [
+// the query that should be sent to the Google search
 {
   name: 'query',
   alias: 'q',
   type: String
-}, // name of the JSON file to save results to
+},
+// name of the JSON file to save results to
 {
   name: 'output',
   alias: 'o',
   type: String
-}, // prevent results from appearing in the terminal output. Should only be used
+},
+// prevent results from appearing in the terminal output. Should only be used
 // with --output (-o) command when saving results to a file
 {
   name: 'no-display',
   alias: 'n',
   type: Boolean
-}, // name of the html file if you want to save the actual response from the
+},
+// name of the html file if you want to save the actual response from the
 // html request
 {
   name: 'save',
   alias: 's',
   type: String
-}, // number of search results to be returned
+},
+// number of search results to be returned
 {
   name: 'limit',
   alias: 'l',
   type: Number
-}, // enable pagination by choosing which result to start at
+},
+// enable pagination by choosing which result to start at
 {
   name: 'start',
   type: Number
-}, // console.log useful statements to show what's currently taking place
+},
+// console.log useful statements to show what's currently taking place
 {
   name: 'verbose',
   alias: 'v',
   type: Boolean
-}, // once results are returned, show them in an interactive prompt where user
+},
+// once results are returned, show them in an interactive prompt where user
 // can scroll through them
 {
   name: 'interactive',
   alias: 'i',
   type: Boolean
-}, // only display the URLs, instead of the titles and snippets
+},
+// only display the URLs, instead of the titles and snippets
 {
   name: 'only-urls',
   alias: 'u',
   type: Boolean
-}, // only takes effect when interactive (-i) flag is set as well, will bold
+},
+// only takes effect when interactive (-i) flag is set as well, will bold
 // test in results that matched the query
 {
   name: 'bold-matching-text',
   alias: 'b',
   type: Boolean
-}, // option to open the first X number of results directly in browser
+},
+// option to open the first X number of results directly in browser
 // (only tested on Mac!).
 {
   name: 'open',
   alias: 'O',
   type: Number
-}, // option to save the html file of the Google search result page
+},
+// option to save the html file of the Google search result page
 {
   name: 'htmlFileOutputPath',
   alias: 'h',
   type: String
-}, // option to use specific HTML file to parse, one that might exist locally
+},
+// option to use specific HTML file to parse, one that might exist locally
 // for example, main for debugging purposes
 {
   name: 'fromFile',
   alias: 'f',
   type: String
-}, // override the hard-coded selectors defined inside /src/utils.js
+},
+// override the hard-coded selectors defined inside /src/utils.js
 {
   name: 'titleSelector',
   type: String
@@ -80,17 +94,20 @@ var optionDefinitions = [// the query that should be sent to the Google search
 }, {
   name: 'snippetSelector',
   type: String
-}, // allows for googleIt result object to include raw network request's response
+},
+// allows for googleIt result object to include raw network request's response
 {
   name: 'diagnostics',
   alias: 'd',
   type: Boolean
-}, // modifies the search query by adding "site:" operator for each comma-separated value,
+},
+// modifies the search query by adding "site:" operator for each comma-separated value,
 // combined with OR operator when there are multiple values
 {
   name: 'includeSites',
   type: String
-}, // modifies the search query by adding "-site:" operator for each comma-separated value,
+},
+// modifies the search query by adding "-site:" operator for each comma-separated value,
 // combined with AND operator when there are multiple values
 {
   name: 'excludeSites',

--- a/lib/parseCommandLineArgs.js
+++ b/lib/parseCommandLineArgs.js
@@ -1,20 +1,16 @@
 "use strict";
 
-var commandLineArgs = require('command-line-args');
-
-var optionDefinitions = require('./optionDefinitions');
-
-var parseCommandLineArgs = function parseCommandLineArgs(argv) {
-  var cliOptions = argv.length === 3 ? {
+const commandLineArgs = require('command-line-args');
+const optionDefinitions = require('./optionDefinitions');
+const parseCommandLineArgs = argv => {
+  const cliOptions = argv.length === 3 ? {
     query: argv[2]
-  } : commandLineArgs(optionDefinitions); // first arg is 'node', second is /path/to/file/app.js, third is whatever follows afterward
-
+  } : commandLineArgs(optionDefinitions);
+  // first arg is 'node', second is /path/to/file/app.js, third is whatever follows afterward
   if (argv.length > 2) {
     // eslint-disable-next-line prefer-destructuring
     cliOptions.query = argv[2].replace('--query=', '');
   }
-
   return cliOptions;
 };
-
 module.exports = parseCommandLineArgs;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,56 +1,48 @@
 "use strict";
 
 /* eslint-disable no-extra-parens */
-
 /* eslint-disable no-console */
-var fs = require('fs');
 
-var _process$env = process.env,
-    GOOGLE_IT_TITLE_SELECTOR = _process$env.GOOGLE_IT_TITLE_SELECTOR,
-    GOOGLE_IT_LINK_SELECTOR = _process$env.GOOGLE_IT_LINK_SELECTOR,
-    GOOGLE_IT_SNIPPET_SELECTOR = _process$env.GOOGLE_IT_SNIPPET_SELECTOR,
-    GOOGLE_IT_RESULT_STATS_SELECTOR = _process$env.GOOGLE_IT_RESULT_STATS_SELECTOR,
-    GOOGLE_IT_CURSOR_SELECTOR = _process$env.GOOGLE_IT_CURSOR_SELECTOR,
-    _process$env$GOOGLE_I = _process$env.GOOGLE_IT_INCLUDE_SITES,
-    GOOGLE_IT_INCLUDE_SITES = _process$env$GOOGLE_I === void 0 ? '' : _process$env$GOOGLE_I,
-    _process$env$GOOGLE_I2 = _process$env.GOOGLE_IT_EXCLUDE_SITES,
-    GOOGLE_IT_EXCLUDE_SITES = _process$env$GOOGLE_I2 === void 0 ? '' : _process$env$GOOGLE_I2; // NOTE:
+const fs = require('fs');
+const {
+  GOOGLE_IT_TITLE_SELECTOR,
+  GOOGLE_IT_TITLE_FINDER,
+  GOOGLE_IT_LINK_SELECTOR,
+  GOOGLE_IT_SNIPPET_SELECTOR,
+  GOOGLE_IT_RESULT_STATS_SELECTOR,
+  GOOGLE_IT_CURSOR_SELECTOR,
+  GOOGLE_IT_INCLUDE_SITES = '',
+  GOOGLE_IT_EXCLUDE_SITES = ''
+} = process.env;
+
+// NOTE:
 // I chose the User-Agent value from http://www.browser-info.net/useragents
 // Not setting one causes Google search to not display results
-
-var defaultUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:34.0) Gecko/20100101 Firefox/34.0';
-var defaultLimit = 10;
-var defaultStart = 0;
-
-var getFullQuery = function getFullQuery(query) {
-  var includeSites = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : GOOGLE_IT_INCLUDE_SITES;
-  var excludeSites = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : GOOGLE_IT_EXCLUDE_SITES;
-
+const defaultUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:34.0) Gecko/20100101 Firefox/34.0';
+const defaultLimit = 10;
+const defaultStart = 0;
+const getFullQuery = function (query) {
+  let includeSites = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : GOOGLE_IT_INCLUDE_SITES;
+  let excludeSites = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : GOOGLE_IT_EXCLUDE_SITES;
   if (includeSites === '' && excludeSites === '') {
     return query;
   }
-
   if (includeSites !== '') {
-    var _addition = includeSites.split(',').map(function (site) {
-      return " site:".concat(site);
-    }).join(' OR');
-
-    return query + _addition;
+    const addition = includeSites.split(',').map(site => ` site:${site}`).join(' OR');
+    return query + addition;
   }
-
-  var addition = excludeSites.split(',').map(function (site) {
-    return " -site:".concat(site);
-  }).join(' AND');
+  const addition = excludeSites.split(',').map(site => ` -site:${site}`).join(' AND');
   return query + addition;
 };
-
-var getDefaultRequestOptions = function getDefaultRequestOptions(_ref) {
-  var limit = _ref.limit,
-      query = _ref.query,
-      userAgent = _ref.userAgent,
-      start = _ref.start,
-      includeSites = _ref.includeSites,
-      excludeSites = _ref.excludeSites;
+const getDefaultRequestOptions = _ref => {
+  let {
+    limit,
+    query,
+    userAgent,
+    start,
+    includeSites,
+    excludeSites
+  } = _ref;
   return {
     url: 'https://www.google.com/search',
     qs: {
@@ -63,75 +55,57 @@ var getDefaultRequestOptions = function getDefaultRequestOptions(_ref) {
     }
   };
 };
-
 var titleSelector = 'div.Gx5Zad.fP1Qef.xpd.EtOod.pkphOe';
 var titlefinder = 'div.BNeawe.vvjwJb.AP7Wnd';
 var linkSelector = 'div.fP1Qef > div:nth-child(1) > a';
-var snippetSelector = '#main > div > div > div > div:not(.v9i61e) > div.AP7Wnd';
-var resultStatsSelector = '#resultStats';
-var cursorSelector = '#nav > tbody > tr > td.cur';
-
-var getTitleSelector = function getTitleSelector(passedValue) {
-  return passedValue || GOOGLE_IT_TITLE_SELECTOR || titleSelector;
-};
-
-var getLinkSelector = function getLinkSelector(passedValue) {
-  return passedValue || GOOGLE_IT_LINK_SELECTOR || linkSelector;
-};
-
-var getSnippetSelector = function getSnippetSelector(passedValue) {
-  return passedValue || GOOGLE_IT_SNIPPET_SELECTOR || snippetSelector;
-};
-
-var getResultStatsSelector = function getResultStatsSelector(passedValue) {
-  return passedValue || GOOGLE_IT_RESULT_STATS_SELECTOR || resultStatsSelector;
-};
-
-var getResultCursorSelector = function getResultCursorSelector(passedValue) {
-  return passedValue || GOOGLE_IT_CURSOR_SELECTOR || cursorSelector;
-};
-
-var logIt = function logIt(message, disableConsole) {
+const snippetSelector = '#main > div > div > div > div:not(.v9i61e) > div.AP7Wnd';
+const resultStatsSelector = '#resultStats';
+const cursorSelector = '#nav > tbody > tr > td.cur';
+const getTitleSelector = passedValue => passedValue || GOOGLE_IT_TITLE_SELECTOR || titleSelector;
+const getTitleFinder = passedValue => passedValue || GOOGLE_IT_TITLE_FINDER || titlefinder;
+const getLinkSelector = passedValue => passedValue || GOOGLE_IT_LINK_SELECTOR || linkSelector;
+const getSnippetSelector = passedValue => passedValue || GOOGLE_IT_SNIPPET_SELECTOR || snippetSelector;
+const getResultStatsSelector = passedValue => passedValue || GOOGLE_IT_RESULT_STATS_SELECTOR || resultStatsSelector;
+const getResultCursorSelector = passedValue => passedValue || GOOGLE_IT_CURSOR_SELECTOR || cursorSelector;
+const logIt = (message, disableConsole) => {
   if (!disableConsole) {
     console.log(message);
   }
 };
-
-var saveToFile = function saveToFile(output, results) {
+const saveToFile = (output, results) => {
   if (output !== undefined) {
-    fs.writeFile(output, JSON.stringify(results, null, 2), 'utf8', function (err) {
+    fs.writeFile(output, JSON.stringify(results, null, 2), 'utf8', err => {
       if (err) {
-        console.error("Error writing to file ".concat(output, ": ").concat(err));
+        console.error(`Error writing to file ${output}: ${err}`);
       }
     });
   }
 };
-
-var saveResponse = function saveResponse(response, htmlFileOutputPath) {
+const saveResponse = (response, htmlFileOutputPath) => {
   if (htmlFileOutputPath) {
-    fs.writeFile(htmlFileOutputPath, response.body, function () {
-      console.log("Html file saved to ".concat(htmlFileOutputPath));
+    fs.writeFile(htmlFileOutputPath, response.body, () => {
+      console.log(`Html file saved to ${htmlFileOutputPath}`);
     });
   }
 };
-
 module.exports = {
-  defaultUserAgent: defaultUserAgent,
-  defaultLimit: defaultLimit,
-  defaultStart: defaultStart,
-  getDefaultRequestOptions: getDefaultRequestOptions,
-  getTitleSelector: getTitleSelector,
-  getLinkSelector: getLinkSelector,
-  titleSelector: titleSelector,
-  titlefinder: titlefinder,
-  linkSelector: linkSelector,
-  snippetSelector: snippetSelector,
-  getSnippetSelector: getSnippetSelector,
-  resultStatsSelector: resultStatsSelector,
-  getResultStatsSelector: getResultStatsSelector,
-  getResultCursorSelector: getResultCursorSelector,
-  logIt: logIt,
-  saveToFile: saveToFile,
-  saveResponse: saveResponse,
-  getFullQuery: getFullQuery
+  defaultUserAgent,
+  defaultLimit,
+  defaultStart,
+  getDefaultRequestOptions,
+  getTitleSelector,
+  getTitleFinder,
+  getLinkSelector,
+  titleSelector,
+  titlefinder,
+  linkSelector,
+  snippetSelector,
+  getSnippetSelector,
+  resultStatsSelector,
+  getResultStatsSelector,
+  getResultCursorSelector,
+  logIt,
+  saveToFile,
+  saveResponse,
+  getFullQuery
 };

--- a/lib/validateCLIArguments.js
+++ b/lib/validateCLIArguments.js
@@ -1,26 +1,23 @@
 "use strict";
 
-var _validationMap;
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
-var MISSING_QUERY = 'missing_query';
-var OUTPUT_ARG_MUST_BE_STRING = 'output_arg_must_be_string';
-var MUST_END_IN_JSON = 'must_end_in_json';
-var ONLY_ONE_NOT_BOTH = 'only_one_not_both';
-
+const MISSING_QUERY = 'missing_query';
+const OUTPUT_ARG_MUST_BE_STRING = 'output_arg_must_be_string';
+const MUST_END_IN_JSON = 'must_end_in_json';
+const ONLY_ONE_NOT_BOTH = 'only_one_not_both';
 function getError(reason) {
   return {
     valid: false,
     Error: reason
   };
 }
-
-var validationMap = (_validationMap = {}, _defineProperty(_validationMap, MISSING_QUERY, getError('Missing query')), _defineProperty(_validationMap, OUTPUT_ARG_MUST_BE_STRING, getError('Output argument must be string')), _defineProperty(_validationMap, MUST_END_IN_JSON, getError('Output argument must end in .json')), _defineProperty(_validationMap, ONLY_ONE_NOT_BOTH, getError('Can only use --no-display when --output is used as well')), _validationMap);
-
+const validationMap = {
+  [MISSING_QUERY]: getError('Missing query'),
+  [OUTPUT_ARG_MUST_BE_STRING]: getError('Output argument must be string'),
+  [MUST_END_IN_JSON]: getError('Output argument must end in .json'),
+  [ONLY_ONE_NOT_BOTH]: getError('Can only use --no-display when --output is used as well')
+};
 function getPotentialError(args) {
-  var error = null;
-
+  let error = null;
   if (!args.query) {
     error = MISSING_QUERY;
   } else if (args.output && typeof args.output !== 'string') {
@@ -30,16 +27,13 @@ function getPotentialError(args) {
   } else if (args['no-display'] && !args.output) {
     error = ONLY_ONE_NOT_BOTH;
   }
-
   return validationMap[error];
 }
-
 function validateCLIArguments(args) {
-  var result = {
+  const result = {
     valid: true
   };
-  var error = getPotentialError(args);
+  const error = getPotentialError(args);
   return error || result;
 }
-
 module.exports = validateCLIArguments;

--- a/src/googleIt.js
+++ b/src/googleIt.js
@@ -10,6 +10,7 @@ const { exec } = require('child_process');
 const {
   getDefaultRequestOptions,
   getTitleSelector,
+  getTitleFinder,
   getLinkSelector,
   getSnippetSelector,
   getResultStatsSelector,
@@ -17,7 +18,6 @@ const {
   logIt,
   saveToFile,
   saveResponse,
-  titlefinder,
 } = require('./utils');
 
 export function errorTryingToOpen(error, stdout, stderr) {
@@ -84,6 +84,7 @@ export function getResults({
   disableConsole,
   onlyUrls,
   titleSelector,
+  titleFinder,
   linkSelector,
   snippetSelector,
   resultStatsSelector,
@@ -92,7 +93,7 @@ export function getResults({
   const $ = cheerio.load(data);
   let results = [];
 
-  const titles = $(getTitleSelector(titleSelector)).find(titlefinder);
+  const titles = $(getTitleSelector(titleSelector)).find(getTitleFinder(titleFinder));
   titles.each((index, elem) => {
     if (elem.children[0].data) {
       results.push({ title: elem.children[0].data });
@@ -180,6 +181,7 @@ function googleIt(config) {
     open,
     returnHtmlBody,
     titleSelector,
+    titleFinder,
     linkSelector,
     snippetSelector,
     resultStatsSelector,
@@ -195,6 +197,7 @@ function googleIt(config) {
         disableConsole: config.disableConsole,
         onlyUrls: config['only-urls'],
         titleSelector,
+        titleFinder,
         linkSelector,
         snippetSelector,
         resultStatsSelector,

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 
 const {
   GOOGLE_IT_TITLE_SELECTOR,
+  GOOGLE_IT_TITLE_FINDER,
   GOOGLE_IT_LINK_SELECTOR,
   GOOGLE_IT_SNIPPET_SELECTOR,
   GOOGLE_IT_RESULT_STATS_SELECTOR,
@@ -62,6 +63,10 @@ const getTitleSelector = (passedValue) => (
   passedValue || GOOGLE_IT_TITLE_SELECTOR || titleSelector
 );
 
+const getTitleFinder = (passedValue) => (
+  passedValue || GOOGLE_IT_TITLE_FINDER || titlefinder
+);
+
 const getLinkSelector = (passedValue) => (
   passedValue || GOOGLE_IT_LINK_SELECTOR || linkSelector
 );
@@ -108,6 +113,7 @@ module.exports = {
   defaultStart,
   getDefaultRequestOptions,
   getTitleSelector,
+  getTitleFinder,
   getLinkSelector,
   titleSelector,
   titlefinder,


### PR DESCRIPTION
All selectors (`titleSelector`, `linkSelector`, `snippetSelector`, `resultStatsSelector`, `cursorSelector`) where exposed via the config object passed to `googleIt()`. For some reason, `titleFinder` was not exposed, which did not allow changing it to adapt the html parser to a new Google Search page structure. 

In this PR I exposed `titleFinder` in the same way as all selectors were. Now, you can change all parameters allowing you to parse the updated Google Search page.

Something to look out for:
- `Build lib` commit - me running `npm run build`, but looks like it reformats a lot of unrelated code. Different version of Babel? Let me know how to proceed. 
- `getResults` test fails. For some reason, the `getResults` function in the test returns 0 results. Meanwhile, `googleIt()` works fine when using the library itself. This test was failing even before my changes, so something must have been broken prior.

Please consider merging changes in [Exposed titleFinder to allow providing your own](https://github.com/PatNeedham/google-it/commit/2052989f720149c74a39d9fd788fc3d8d2323e0f) since they fix functionality of this library. Sometimes Google returns a new style of the search page, so it is important to provide your own selectors and `titleFinder`.